### PR TITLE
Use remote_ip instead of ip

### DIFF
--- a/lib/devise_invalidatable/hooks/invalidatable.rb
+++ b/lib/devise_invalidatable/hooks/invalidatable.rb
@@ -6,7 +6,7 @@
 # easier to just use our own id.
 Warden::Manager.after_set_user except: :fetch do |user, warden, _|
   UserSession.deactivate(warden.raw_session['auth_id'])
-  warden.raw_session['auth_id'] = user.activate_session(ip: warden.request.ip,
+  warden.raw_session['auth_id'] = user.activate_session(ip: warden.request.remote_ip,
                                                         user_agent: warden.request.user_agent)
 end
 


### PR DESCRIPTION
Use `remote_ip` method provided by Rails instead of `ip` method provided
by Rack. This is consistent with how other devise modules work. For
example:

https://github.com/plataformatec/devise/blob/715192a7709a4c02127afb067e66230061b82cf2/lib/devise/models/trackable.rb#L46